### PR TITLE
Update ext.url_helper.php

### DIFF
--- a/addons/url_helper/ext.url_helper.php
+++ b/addons/url_helper/ext.url_helper.php
@@ -61,6 +61,12 @@ class Url_helper_ext
      */
     public $version = URL_HELPER_VERSION;
 
+
+    /**
+     * @var array
+     */
+    public config = [];
+
     /**
      * @param string $settings
      */


### PR DESCRIPTION
Fix php 8.2 warning 
```
Creation of dynamic property Url_helper_ext::$config is deprecated
user/addons/url_helper/ext.url_helper.php, line 71
```